### PR TITLE
Add --region param to `ecs_run.rb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Usage: ecs_run.rb [options] [command or STDIN]
     -s, --service=SERVICE            Service name
     -w, --watch                      Watch output
     -r, --ruby                       Run input as Ruby code with Rails runner (instead of shell command)
+    -R, --region                     AWS region to use
 ```
 
 Note that the command is non-interactive - you provide the code and you watch it execute.

--- a/ecs_run.rb
+++ b/ecs_run.rb
@@ -25,8 +25,8 @@ OptionParser.new do |opts|
     config[:ruby] = true
   end
 
-  opts.on('-R', '--region', 'Aws region') do |r|
-    config[:region] = true
+  opts.on('-R', '--region=REGION', 'Aws region') do |r|
+    config[:region] = r
   end
 end.parse!
 raise OptionParser::MissingArgument, 'cluster' if config[:cluster].nil?

--- a/ecs_run.rb
+++ b/ecs_run.rb
@@ -24,6 +24,10 @@ OptionParser.new do |opts|
   opts.on('-r', '--ruby', 'Run input as Ruby code with Rails runner (instead of shell command)') do |r|
     config[:ruby] = true
   end
+
+  opts.on('-R', '--region', 'Aws region') do |r|
+    config[:region] = true
+  end
 end.parse!
 raise OptionParser::MissingArgument, 'cluster' if config[:cluster].nil?
 raise OptionParser::MissingArgument, 'service' if config[:service].nil?
@@ -38,7 +42,12 @@ unless command
 end
 command = "bundle exec rails runner #{command.shellescape}" if config[:ruby]
 
-client = Aws::ECS::Client.new
+client_opts = {}
+client_opts[:region] = config[:region] if config[:region]
+client = Aws::ECS::Client.new(client_opts)
+unless client_opts[:region]
+  puts "No region is specified. Using #{client.config.region}"
+end
 
 resp = client.describe_services(
   cluster: config[:cluster],


### PR DESCRIPTION
### issue 
I had misconfigured default region in `~/.aws/config`. This caused empty clusters list and further no cluster errors. 
By this week we allow to specify `--region` param and output what is the current region running the command.