### PR TITLE
Param tool enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Usage: AWS_REGION=<your_region> param_tool.rb [options] (down|up)
     -k, --key=KEY                    Encryption key for writing secure params (no effect on reading)
     -d, --decrypt                    Output decrypted params
     -y, --yes                        Apply changes without asking for confirmation (DANGER)
+    -D, --description=STRING         Add description to params
 ```
 
 ### Download params

--- a/param_tool.rb
+++ b/param_tool.rb
@@ -188,9 +188,9 @@ elsif ARGV[0] == 'up'
   new_param_tree =
     begin
       if config[:file]
-        File.open(config[:file]) { |f| YAML.safe_load(f.read) }
+        File.open(config[:file]) { |f| YAML.safe_load(f.read, aliases: true) }
       else
-        YAML.safe_load(STDIN.read)
+        YAML.safe_load(STDIN.read, aliases: true)
       end
     rescue StandardError => e
       raise "Failed to read params YAML: #{e}"

--- a/param_tool.rb
+++ b/param_tool.rb
@@ -34,6 +34,10 @@ OptionParser.new do |opts|
   opts.on("-y", "--yes", "Apply changes without asking for confirmation (DANGER)") do
     config[:yes] = true
   end
+
+  opts.on("-D", "--description=STRING", "Add description to params") do |k|
+    config[:description] = k
+  end
 end.parse!
 raise OptionParser::MissingArgument, 'prefix' if config[:prefix].nil?
 
@@ -140,7 +144,9 @@ def apply_write_plan(config, client, plan)
           value: item[:value],
           type: item[:secure] ? 'SecureString' : 'String',
           key_id: item[:secure] ? config[:key] : nil,
-          overwrite: item[:operation] == :update
+          overwrite: item[:operation] == :update,
+          tier: 'Intelligent-Tiering',
+          description: config[:description]
         )
         puts 'done'
       end


### PR DESCRIPTION
- Allow setting description for params
- Allow params to be longer than 4KB (by use of intelligent tiering, that will upgrade them to paid 8KB params when needed)
- Allow using aliases in the param source YAML