### PR TITLE
Add `startedBy` parameter to ECS tasks started with `ecs_run.rb`

### DIFF
--- a/ecs_run.rb
+++ b/ecs_run.rb
@@ -114,7 +114,8 @@ task_response = client.run_task(
       security_groups: [security_group],
       assign_public_ip: 'ENABLED'
     }
-  }
+  },
+  started_by: 'aws_ecs_tools/ecs_run'
 )
 
 task_arn = task_response.tasks[0].task_arn


### PR DESCRIPTION
## Motivation

- #reason There was a case with hanging ecs tasks without ecs service and empty started_by
  - they were started using `ecs_run.rb` script tool
  - #dk Tasks started by CodeDeploy or scaling activities have 'startedBy' specified
  - #dk It's not possible to specify timeout for ECS task

## Changes

- Specify 'startedBy' parameter for easier debug of ECS tasks

## How to test
- Should work as before

## Images and GIFs

![CleanShot 2023-06-08 at 18 09 25](https://github.com/railsware/aws-ecs-tools/assets/17218559/8d7d2b24-d268-4bfe-ba96-df6c74f56c3c)
