### PR TITLE
Skip empty strings from params plan

### DIFF
--- a/param_tool.rb
+++ b/param_tool.rb
@@ -70,7 +70,7 @@ def build_write_params_plan(client, config, old_param_tree, keypath, value)
     value.each.with_index.flat_map do |child, index|
       build_write_params_plan(client, config, old_param_tree, keypath + [index], child)
     end
-  elsif value.nil?
+  elsif value.nil? || value == ''
     # skip params without value set
     []
   else


### PR DESCRIPTION
## Motivation

Empty values are not allowed in SSM param store anyway. Skip them from plan

## How to test
```
# params.yml
key_without_value: ''

param_tool.rb --prefix /staging/myapp --file params.yml up
```